### PR TITLE
Enable looping movie carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,137 @@
     </div>
   </section>
 
+  <section class="movie-row">
+    <h2>Action Hits</h2>
+    <button class="arrow arrow-left">&#10094;</button>
+    <button class="arrow arrow-right">&#10095;</button>
+    <div class="movie-thumbnails">
+      <img src="assets/movies/Ace Ventura.jpg" alt="Ace Ventura movie poster" />
+      <img src="assets/movies/Addams Family TV.jpg" alt="Addams Family TV movie poster" />
+      <img src="assets/movies/Addams Family.jpg" alt="Addams Family movie poster" />
+      <img src="assets/movies/Airplane.jpg" alt="Airplane movie poster" />
+      <img src="assets/movies/Aladdin-2.jpg" alt="Aladdin 2 movie poster" />
+      <img src="assets/movies/Alex-Cross-1.jpg" alt="Alex Cross 1 movie poster" />
+      <img src="assets/movies/Alex-Cross-2.jpg" alt="Alex Cross 2 movie poster" />
+      <img src="assets/movies/Alex-Cross-3.jpg" alt="Alex Cross 3 movie poster" />
+      <img src="assets/movies/Alice in Wonderland.jpg" alt="Alice in Wonderland movie poster" />
+      <img src="assets/movies/Alien and Predator.jpg" alt="Alien and Predator movie poster" />
+      <img src="assets/movies/All-Dogs.jpg" alt="All Dogs movie poster" />
+      <img src="assets/movies/Allan Quatermain.jpg" alt="Allan Quatermain movie poster" />
+      <img src="assets/movies/Almighty.jpg" alt="Almighty movie poster" />
+      <img src="assets/movies/Alvin and the Chipmunks.jpg" alt="Alvin and the Chipmunks movie poster" />
+      <img src="assets/movies/American Psycho.jpg" alt="American Psycho movie poster" />
+      <img src="assets/movies/Amityville.jpg" alt="Amityville movie poster" />
+      <img src="assets/movies/Anchorman.jpg" alt="Anchorman movie poster" />
+      <img src="assets/movies/Ant-Man-1.jpg" alt="Ant-Man 1 movie poster" />
+      <img src="assets/movies/Ant-Man-2.jpg" alt="Ant-Man 2 movie poster" />
+      <img src="assets/movies/Appleseed.jpg" alt="Appleseed movie poster" />
+      <img src="assets/movies/Are We.jpg" alt="Are We movie poster" />
+      <img src="assets/movies/Armour of God.jpg" alt="Armour of God movie poster" />
+      <img src="assets/movies/Asterix Obelix.jpg" alt="Asterix Obelix movie poster" />
+      <img src="assets/movies/Atlas Shrugged.jpg" alt="Atlas Shrugged movie poster" />
+      <img src="assets/movies/Attack On Titan.jpg" alt="Attack On Titan movie poster" />
+    </div>
+  </section>
+  
+  <section class="movie-row">
+    <h2>Comedy Favorites</h2>
+    <button class="arrow arrow-left">&#10094;</button>
+    <button class="arrow arrow-right">&#10095;</button>
+    <div class="movie-thumbnails">
+      <img src="assets/movies/Austin Powers.jpg" alt="Austin Powers movie poster" />
+      <img src="assets/movies/Avatar-Last-Airbender.jpg" alt="Avatar Last Airbender movie poster" />
+      <img src="assets/movies/Avengers 1.jpg" alt="Avengers 1 movie poster" />
+      <img src="assets/movies/Avengers 2.jpg" alt="Avengers 2 movie poster" />
+      <img src="assets/movies/Avengers 3.jpg" alt="Avengers 3 movie poster" />
+      <img src="assets/movies/Azumi.jpg" alt="Azumi movie poster" />
+      <img src="assets/movies/Back to the Future.jpg" alt="Back to the Future movie poster" />
+      <img src="assets/movies/Bad Santa.jpg" alt="Bad Santa movie poster" />
+      <img src="assets/movies/Bad moms.jpg" alt="Bad moms movie poster" />
+      <img src="assets/movies/Balto.jpg" alt="Balto movie poster" />
+      <img src="assets/movies/Barbershop.jpg" alt="Barbershop movie poster" />
+      <img src="assets/movies/Basic Instinct.jpg" alt="Basic Instinct movie poster" />
+      <img src="assets/movies/Batman-Animated-2.jpg" alt="Batman Animated 2 movie poster" />
+      <img src="assets/movies/Batman-Animated.jpg" alt="Batman Animated movie poster" />
+      <img src="assets/movies/Batman.jpg" alt="Batman movie poster" />
+      <img src="assets/movies/Battle Royale.jpg" alt="Battle Royale movie poster" />
+      <img src="assets/movies/Best-of-the-best.jpg" alt="Best of the Best movie poster" />
+      <img src="assets/movies/Beverly Hills Cop.jpg" alt="Beverly Hills Cop movie poster" />
+      <img src="assets/movies/Big Fat Greek Wedding.jpg" alt="Big Fat Greek Wedding movie poster" />
+      <img src="assets/movies/Big Momma.jpg" alt="Big Momma movie poster" />
+      <img src="assets/movies/Bill Ted Excelent.jpg" alt="Bill Ted Excelent movie poster" />
+      <img src="assets/movies/Blade Runner.jpg" alt="Blade Runner movie poster" />
+      <img src="assets/movies/Blade.jpg" alt="Blade movie poster" />
+      <img src="assets/movies/Blair Witch.jpg" alt="Blair Witch movie poster" />
+      <img src="assets/movies/Bogeyman.jpg" alt="Bogeyman movie poster" />
+    </div>
+  </section>
+  
+  <section class="movie-row">
+    <h2>Sci-Fi Classics</h2>
+    <button class="arrow arrow-left">&#10094;</button>
+    <button class="arrow arrow-right">&#10095;</button>
+    <div class="movie-thumbnails">
+      <img src="assets/movies/Boondock Saints.jpg" alt="Boondock Saints movie poster" />
+      <img src="assets/movies/Brave-LIttle-Toaster.jpg" alt="Brave Little Toaster movie poster" />
+      <img src="assets/movies/Bridget Jones.jpg" alt="Bridget Jones movie poster" />
+      <img src="assets/movies/Bring it On.jpg" alt="Bring it On movie poster" />
+      <img src="assets/movies/Bud Spencer Terence Hill.jpg" alt="Bud Spencer Terence Hill movie poster" />
+      <img src="assets/movies/Butterfly Effect.jpg" alt="Butterfly Effect movie poster" />
+      <img src="assets/movies/CSI.jpg" alt="CSI movie poster" />
+      <img src="assets/movies/Candyman.jpg" alt="Candyman movie poster" />
+      <img src="assets/movies/Captaina America 1.jpg" alt="Captaina America 1 movie poster" />
+      <img src="assets/movies/Captaina America 2.jpg" alt="Captaina America 2 movie poster" />
+      <img src="assets/movies/Captaina America 3.jpg" alt="Captaina America 3 movie poster" />
+      <img src="assets/movies/Carry-on.jpg" alt="Carry-on movie poster" />
+      <img src="assets/movies/Cars.jpg" alt="Cars movie poster" />
+      <img src="assets/movies/Cats and Dogs.jpg" alt="Cats and Dogs movie poster" />
+      <img src="assets/movies/Cell.jpg" alt="Cell movie poster" />
+      <img src="assets/movies/Charlies Angels 2.jpg" alt="Charlies Angels 2 movie poster" />
+      <img src="assets/movies/Charlies Angels.jpg" alt="Charlies Angels movie poster" />
+      <img src="assets/movies/Christmas.jpg" alt="Christmas movie poster" />
+      <img src="assets/movies/Chronicles of Narnia.jpg" alt="Chronicles of Narnia movie poster" />
+      <img src="assets/movies/Chucky.jpg" alt="Chucky movie poster" />
+      <img src="assets/movies/Clash Of the Titans.jpg" alt="Clash Of the Titans movie poster" />
+      <img src="assets/movies/Clerks.jpg" alt="Clerks movie poster" />
+      <img src="assets/movies/Cloudy with a chance of Meatballs.jpg" alt="Cloudy with a Chance of Meatballs movie poster" />
+      <img src="assets/movies/Cloverfield.jpg" alt="Cloverfield movie poster" />
+      <img src="assets/movies/Cocoon.jpg" alt="Cocoon movie poster" />
+    </div>
+  </section>
+  
+  <section class="movie-row">
+    <h2>Family Fun</h2>
+    <button class="arrow arrow-left">&#10094;</button>
+    <button class="arrow arrow-right">&#10095;</button>
+    <div class="movie-thumbnails">
+      <img src="assets/movies/Conan the Barbarian 1.jpg" alt="Conan the Barbarian 1 movie poster" />
+      <img src="assets/movies/Conan the Barbarian 2.jpg" alt="Conan the Barbarian 2 movie poster" />
+      <img src="assets/movies/Conjuring.jpg" alt="Conjuring movie poster" />
+      <img src="assets/movies/Cornetto.jpg" alt="Cornetto movie poster" />
+      <img src="assets/movies/Crank.jpg" alt="Crank movie poster" />
+      <img src="assets/movies/Crimson Rivers.jpg" alt="Crimson Rivers movie poster" />
+      <img src="assets/movies/Crocodile Dundee.jpg" alt="Crocodile Dundee movie poster" />
+      <img src="assets/movies/Crow.jpg" alt="Crow movie poster" />
+      <img src="assets/movies/Cube.jpg" alt="Cube movie poster" />
+      <img src="assets/movies/Cutting Edge.jpg" alt="Cutting Edge movie poster" />
+      <img src="assets/movies/DC Universe.jpg" alt="DC Universe movie poster" />
+      <img src="assets/movies/DC-animated.jpg" alt="DC animated movie poster" />
+      <img src="assets/movies/Dad Moms.jpg" alt="Dad Moms movie poster" />
+      <img src="assets/movies/Daddys Home.jpg" alt="Daddys Home movie poster" />
+      <img src="assets/movies/Dark Knight.jpg" alt="Dark Knight movie poster" />
+      <img src="assets/movies/Darko.jpg" alt="Darko movie poster" />
+      <img src="assets/movies/Death-Note.jpg" alt="Death-Note movie poster" />
+      <img src="assets/movies/Death-race.jpg" alt="Death-race movie poster" />
+      <img src="assets/movies/Deep Blue Sea.jpg" alt="Deep Blue Sea movie poster" />
+      <img src="assets/movies/Despicable Me.jpg" alt="Despicable Me movie poster" />
+      <img src="assets/movies/Deuce Bigalow.jpg" alt="Deuce Bigalow movie poster" />
+      <img src="assets/movies/Die Hard.jpg" alt="Die Hard movie poster" />
+      <img src="assets/movies/Dirty Dancing.jpg" alt="Dirty Dancing movie poster" />
+      <img src="assets/movies/Dirty-Harry.jpg" alt="Dirty Harry movie poster" />
+      <img src="assets/movies/Disney Studios.jpg" alt="Disney Studios movie poster" />
+    </div>
+  </section>
   </main>
 
 </body>

--- a/script.js
+++ b/script.js
@@ -48,33 +48,43 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   // ======= MOVIE CAROUSEL =======
-  const rows = document.querySelectorAll(".movie-row");
-  rows.forEach((row) => {
-    const container = row.querySelector(".movie-thumbnails");
-    if (!container) return;
-    const left = row.querySelector(".arrow-left");
-    const right = row.querySelector(".arrow-right");
+  function setupCarousel() {
+    const rows = document.querySelectorAll(".movie-row");
+    rows.forEach((row) => {
+      const container = row.querySelector(".movie-thumbnails");
+      if (!container) return;
+      const left = row.querySelector(".arrow-left");
+      const right = row.querySelector(".arrow-right");
 
-    // Clone thumbnails for seamless looping
-    const images = Array.from(container.children);
-    images.forEach((img) => {
-      container.appendChild(img.cloneNode(true));
+      // Clone thumbnails for seamless looping
+      const images = Array.from(container.children);
+      images.forEach((img) => {
+        container.appendChild(img.cloneNode(true));
+      });
+
+      const gap = parseInt(getComputedStyle(container).gap) || 15;
+      const scrollStep = images[0].offsetWidth + gap;
+
+      right?.addEventListener("click", () => {
+        if (container.scrollLeft >= container.scrollWidth / 2) {
+          container.scrollLeft = 0;
+        }
+        container.scrollBy({ left: scrollStep, behavior: "smooth" });
+      });
+
+      left?.addEventListener("click", () => {
+        if (container.scrollLeft <= 0) {
+          container.scrollLeft = container.scrollWidth / 2;
+        }
+        container.scrollBy({ left: -scrollStep, behavior: "smooth" });
+      });
     });
+  }
 
-    const scrollStep = images[0]?.offsetWidth + 15 || 200;
-
-    right?.addEventListener("click", () => {
-      if (container.scrollLeft >= container.scrollWidth / 2) {
-        container.scrollLeft = 0;
-      }
-      container.scrollBy({ left: scrollStep, behavior: "smooth" });
-    });
-
-    left?.addEventListener("click", () => {
-      if (container.scrollLeft <= 0) {
-        container.scrollLeft = container.scrollWidth / 2;
-      }
-      container.scrollBy({ left: -scrollStep, behavior: "smooth" });
-    });
-  });
+  // Ensure images are loaded before calculating widths
+  if (document.readyState === "complete") {
+    setupCarousel();
+  } else {
+    window.addEventListener("load", setupCarousel);
+  }
 });


### PR DESCRIPTION
## Summary
- initialize carousel once images have loaded
- compute scroll step from actual image width for smoother looping
- add four more movie rows filled with many movies

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684513f9257883309a1ac6f0955aca3c